### PR TITLE
feat(tags): add sort by and sort direction controls on tag page

### DIFF
--- a/pocketbase/pb_migrations/1773300695_updated_tags.js
+++ b/pocketbase/pb_migrations/1773300695_updated_tags.js
@@ -1,0 +1,48 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("35y5ayizwh2c9fk")
+
+  // add field
+  collection.fields.addAt(6, new Field({
+    "hidden": false,
+    "id": "select1582199508",
+    "maxSelect": 1,
+    "name": "sortBy",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "select",
+    "values": [
+      "created",
+      "alphabetical"
+    ]
+  }))
+
+  // add field
+  collection.fields.addAt(7, new Field({
+    "hidden": false,
+    "id": "select1372728543",
+    "maxSelect": 1,
+    "name": "sortDirection",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "select",
+    "values": [
+      "asc",
+      "desc"
+    ]
+  }))
+
+  return app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("35y5ayizwh2c9fk")
+
+  // remove field
+  collection.fields.removeById("select1582199508")
+
+  // remove field
+  collection.fields.removeById("select1372728543")
+
+  return app.save(collection)
+})

--- a/src/routes/_layout.$journalId.tags.$tagId.tsx
+++ b/src/routes/_layout.$journalId.tags.$tagId.tsx
@@ -3,6 +3,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import Delta from "quill-delta";
+import { useMemo } from "react";
 import isAuthenticated from "src/Users/utils/isAuthenticated";
 import { Button } from "src/common/components/Button/Button";
 import { Toolbar } from "src/common/components/Toolbar/Toolbar";
@@ -44,6 +45,37 @@ export default function TagComponent() {
   const { note } = useGetNote({ noteId });
   const { createNote } = useCreateNote();
   const { updateTag } = useUpdateTag();
+
+  const sortBy = tag?.sortBy ?? "created";
+  const sortDirection = tag?.sortDirection ?? "asc";
+
+  const sortedNotes = useMemo(() => {
+    const noteCopy = [...notes];
+
+    noteCopy.sort((a, b) => {
+      let compareVal = 0;
+
+      if (sortBy === "alphabetical") {
+        const titleA = a.title ?? "";
+        const titleB = b.title ?? "";
+
+        compareVal = titleA.localeCompare(titleB, undefined, {
+          sensitivity: "base",
+          numeric: true,
+        });
+      } else {
+        compareVal = a.created.valueOf() - b.created.valueOf();
+      }
+
+      if (sortDirection === "desc") {
+        compareVal = -compareVal;
+      }
+
+      return compareVal;
+    });
+
+    return noteCopy;
+  }, [notes, sortBy, sortDirection]);
 
   if (!tag) {
     return null;
@@ -177,8 +209,18 @@ export default function TagComponent() {
                 </DropdownMenu.RadioGroup>
 
                 <DropdownMenu.RadioGroup
-                  value={"created"}
-                  onValueChange={() => {}}
+                  value={tag.sortBy}
+                  onValueChange={(value) => {
+                    if (value === "created" || value === "alphabetical") {
+                      updateTag({
+                        tagId: tag.id,
+                        updateTagData: {
+                          ...tag,
+                          sortBy: value,
+                        },
+                      });
+                    }
+                  }}
                 >
                   <DropdownMenu.Label className="pl-2 text-xs text-slate-400">
                     Sort by
@@ -203,9 +245,55 @@ export default function TagComponent() {
                       `data-[highlighted]:${tag.colour.backgroundPill}`,
                       `data-[highlighted]:${tag.colour.textPill}`,
                     )}
-                    value="title"
+                    value="alphabetical"
                   >
-                    Title
+                    Alphabetical
+                    <DropdownMenu.ItemIndicator>
+                      <Check />
+                    </DropdownMenu.ItemIndicator>
+                  </DropdownMenu.RadioItem>
+                </DropdownMenu.RadioGroup>
+
+                <DropdownMenu.RadioGroup
+                  value={tag.sortDirection}
+                  onValueChange={(value) => {
+                    if (value === "asc" || value === "desc") {
+                      updateTag({
+                        tagId: tag.id,
+                        updateTagData: {
+                          ...tag,
+                          sortDirection: value,
+                        },
+                      });
+                    }
+                  }}
+                >
+                  <DropdownMenu.Label className="pl-2 text-xs text-slate-400">
+                    Sort direction
+                  </DropdownMenu.Label>
+
+                  <DropdownMenu.RadioItem
+                    className={cn(
+                      "leading-none text-sm p-2 flex justify-between items-center outline-none rounded-xl cursor-pointer transition-colors",
+                      `data-[highlighted]:${tag.colour.backgroundPill}`,
+                      `data-[highlighted]:${tag.colour.textPill}`,
+                    )}
+                    value="asc"
+                  >
+                    Ascending
+                    <DropdownMenu.ItemIndicator>
+                      <Check />
+                    </DropdownMenu.ItemIndicator>
+                  </DropdownMenu.RadioItem>
+                  <DropdownMenu.RadioItem
+                    className={cn(
+                      "leading-none text-sm p-2 flex justify-between items-center outline-none rounded-xl cursor-pointer transition-colors",
+                      `data-[highlighted]:${tag.colour.backgroundPill}`,
+                      `data-[highlighted]:${tag.colour.textPill}`,
+                    )}
+                    value="desc"
+                  >
+                    Descending
                     <DropdownMenu.ItemIndicator>
                       <Check />
                     </DropdownMenu.ItemIndicator>
@@ -229,7 +317,7 @@ export default function TagComponent() {
         description={tag.description}
         links={tag.badges}
         colour={tag.colour}
-        notes={notes}
+        notes={sortedNotes}
         selectedNote={note || null}
         prefillNewNoteData={{ tags: [tag] }}
         groupNotesBy={tag.groupBy ?? undefined}

--- a/src/tags/Tag.type.ts
+++ b/src/tags/Tag.type.ts
@@ -23,6 +23,8 @@ export type Tag = {
   description: string | null;
   noteCount: number;
   groupBy: "created" | "tag" | null;
+  sortBy: "alphabetical" | "created";
+  sortDirection: "asc" | "desc";
   badges: TagBadge[];
   tagGroupId: string | null;
   created: Dayjs;

--- a/src/tags/components/CreateTagModal/CreateTagModal.tsx
+++ b/src/tags/components/CreateTagModal/CreateTagModal.tsx
@@ -23,6 +23,8 @@ const getInitialTag = (tagGroupId?: string): NewTag => ({
   icon: "tag",
   badges: [],
   tagGroupId: tagGroupId ?? null,
+  sortBy: "created",
+  sortDirection: "asc",
 });
 
 export const CreateTagModal = ({ tagGroupId }: CreateTagModalProps) => {

--- a/src/tags/components/TagMultiSelect/TagMultiSelect.tsx
+++ b/src/tags/components/TagMultiSelect/TagMultiSelect.tsx
@@ -54,6 +54,8 @@ export const TagMultiSelect = ({
         tagGroupId: null,
         colour: colours.orange,
         icon: "tag",
+        sortBy: "created",
+        sortDirection: "asc",
       },
     });
     const newTags = [...selectedTags, newTag];

--- a/src/tags/hooks/useCreateTag.ts
+++ b/src/tags/hooks/useCreateTag.ts
@@ -38,6 +38,8 @@ export const useCreateTag = (): UseCreateTagResponse => {
       journal: journalId,
       user: user?.id,
       groupBy: null,
+      sortBy: createTagData.sortBy ?? "created",
+      sortDirection: createTagData.sortDirection ?? "asc",
     });
 
     const mappedNewTag = mapTag({ ...newTag, totalNotes: 0 });

--- a/src/tags/utils/mapTag.ts
+++ b/src/tags/utils/mapTag.ts
@@ -12,6 +12,8 @@ export const mapTag = (tag: RecordModel): Tag => {
     noteCount: tag.totalNotes,
     badges: tag.badges || [],
     groupBy: tag.groupBy,
+    sortBy: tag.sortBy ?? "created",
+    sortDirection: tag.sortDirection ?? "asc",
     tagGroupId: tag.tagGroup || null,
     created: tag.createdAt,
     updated: tag.updatedAt,


### PR DESCRIPTION
- Added tag properties sortBy and sortDirection to Tag type\n- Persisted these fields from PB mapping and create/update paths\n- Added Sort by + Sort direction radio groups in tag page dropdown\n- Added note-sorting logic in Tag page based on these fields\n- Ensured TypeScript/lint/build passes