### PR TITLE
Create next task on Enter in task title editor

### DIFF
--- a/src/notes/components/NoteEditor/NoteEditor.tsx
+++ b/src/notes/components/NoteEditor/NoteEditor.tsx
@@ -271,6 +271,7 @@ const NoteEditor = ({
               key={task.id}
               task={task}
               colour={colour}
+              onCreateNextTask={onCreateTask}
               autoFocusTitle={task.id === newTaskFocusId}
               onAutoFocusComplete={() => setNewTaskFocusId(null)}
             />

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -26,6 +26,7 @@ type TaskEditorProps = {
   task?: Partial<Task>;
   onSave?: () => void;
   onCreate?: (task: Task) => void;
+  onCreateNextTask?: () => void | Promise<void>;
   onFocusLost?: () => void;
   autoFocusTitle?: boolean;
   onAutoFocusComplete?: () => void;
@@ -53,6 +54,7 @@ export const TaskEditor = ({
   task,
   onSave,
   onCreate,
+  onCreateNextTask,
   onFocusLost,
   autoFocusTitle = false,
   onAutoFocusComplete,
@@ -334,6 +336,16 @@ export const TaskEditor = ({
               name="title"
               value={editedTask.title ?? ""}
               placeholder="No Title"
+              onKeyDown={async (e) => {
+                if (e.key !== "Enter" || e.shiftKey) {
+                  return;
+                }
+
+                e.preventDefault();
+                debouncedSave.flush();
+                await saveRef.current?.();
+                await onCreateNextTask?.();
+              }}
               onChange={(e) =>
                 onUpdateTask({
                   title: e.target.value,

--- a/src/tasks/components/TasksSection/TasksSection.tsx
+++ b/src/tasks/components/TasksSection/TasksSection.tsx
@@ -109,6 +109,7 @@ export const TasksSection = ({
               key={task.id}
               task={task}
               colour={colour}
+              onCreateNextTask={onCreateTask}
               autoFocusTitle={task.id === newTaskFocusId}
               onAutoFocusComplete={() => setNewTaskFocusId(null)}
             />
@@ -161,6 +162,7 @@ export const TasksSection = ({
             key={task.id}
             task={task}
             colour={colour}
+            onCreateNextTask={onCreateTask}
             autoFocusTitle={task.id === newTaskFocusId}
             onAutoFocusComplete={() => setNewTaskFocusId(null)}
           />


### PR DESCRIPTION
## Why
When quickly entering tasks, pressing Enter in the title field should continue task entry flow instead of only inserting a newline. This makes rapid task capture faster and more consistent with checklist-style editing.

## What changed
- Added an `onCreateNextTask` callback to `TaskEditor`.
- In the task title textarea, pressing `Enter` (without Shift) now:
  - prevents the default newline,
  - flushes/saves the current task,
  - creates a new task via the parent callback.
- Wired `onCreateNextTask` in both task list contexts:
  - `TasksSection`
  - `NoteEditor`

## Notes
- `Shift+Enter` is unchanged and still inserts a newline in the title field.
- Newly created tasks continue using the existing autofocus behavior, so focus moves to the new task title automatically.