### PR TITLE
Polish notes and tasks editor layout and visual hierarchy

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -58,13 +58,13 @@ const createWindow = () => {
   const isWindows = process.platform === "win32";
 
   mainWindow = new BrowserWindow({
-    width: isDev ? 2400 : 1200,
+    width: isDev ? 2000 : 1000,
     height: 800,
     title: "Pocketbook",
     titleBarStyle: "hidden",
     ...(isMac
       ? {
-          trafficLightPosition: { x: 21, y: 21 },
+          trafficLightPosition: { x: 18, y: 18 },
         }
       : {}),
     ...(isWindows
@@ -73,7 +73,7 @@ const createWindow = () => {
           titleBarOverlay: {
             color: "#ffffff00",
             symbolColor: "#64748b",
-            height: 58,
+            height: 50,
           },
         }
       : {}),

--- a/src/common/components/FloatingToolbar/FloatingToolbar.tsx
+++ b/src/common/components/FloatingToolbar/FloatingToolbar.tsx
@@ -10,7 +10,7 @@ export const FloatingToolbar = ({ visible, children }: FloatingToolbarProps) => 
     <div
       onMouseDown={(e) => e.preventDefault()}
       className={cn(
-        "bg-white rounded-2xl shadow-lg border border-slate-200 px-3 py-2",
+        "bg-white rounded-2xl shadow-md border border-slate-200 px-3 py-2",
         "transition-all duration-200 ease-out",
         // translate-y-3 (12px) provides a subtle upward slide-in effect
         visible ? "translate-y-0 opacity-100 pointer-events-auto" : "translate-y-3 opacity-0 pointer-events-none",

--- a/src/common/components/FloatingToolbar/FloatingToolbar.tsx
+++ b/src/common/components/FloatingToolbar/FloatingToolbar.tsx
@@ -10,7 +10,7 @@ export const FloatingToolbar = ({ visible, children }: FloatingToolbarProps) => 
     <div
       onMouseDown={(e) => e.preventDefault()}
       className={cn(
-        "bg-white rounded-2xl shadow-lg border border-slate-100 px-3 py-2",
+        "bg-white rounded-2xl shadow-lg border border-slate-200 px-3 py-2",
         "transition-all duration-200 ease-out",
         // translate-y-3 (12px) provides a subtle upward slide-in effect
         visible ? "translate-y-0 opacity-100 pointer-events-auto" : "translate-y-3 opacity-0 pointer-events-none",

--- a/src/common/components/QuillFormattingToolbar/QuillFormattingToolbarButton.tsx
+++ b/src/common/components/QuillFormattingToolbar/QuillFormattingToolbarButton.tsx
@@ -36,7 +36,7 @@ export const QuillFormattingToolbarButton = ({
       ref={refCallback}
       className={cn(
         quillClass,
-        "rounded-md text-slate-400 px-2 py-1",
+        "rounded-md text-slate-500 px-2 py-1",
         `hover:${colour.backgroundPill}`,
         `hover:${colour.textPill}`,
         `data-[state=on]:${colour.backgroundPill}`,

--- a/src/common/components/Sidebar/Sidebar.tsx
+++ b/src/common/components/Sidebar/Sidebar.tsx
@@ -69,7 +69,7 @@ export const Sidebar = () => {
           pocketbooks={pocketbooks}
         />
 
-        <section className="flex flex-col gap-1">
+        <section className="flex flex-col">
           <NavItem
             ghost
             iconName="pencil"

--- a/src/common/components/Sidebar/Sidebar.tsx
+++ b/src/common/components/Sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ export const Sidebar = () => {
     <aside className="bg-slate-50 min-w-60 max-w-60 flex flex-col h-full">
       <div
         className={cn(
-          "flex flex-row items-center gap-2 electron-drag-region flex-shrink-0 h-[58px] px-3",
+          "flex flex-row items-center gap-2 electron-drag-region flex-shrink-0 h-[50px] p-2",
           isWindows ? "justify-between" : "justify-end",
         )}
       >
@@ -140,7 +140,7 @@ export const Sidebar = () => {
           </SidebarTagSection>
         ))}
 
-        <hr className="w-full border-slate-200" />
+        <hr className="w-full border-slate-300" />
 
         <Dialog.Root>
           <Dialog.Trigger asChild>

--- a/src/common/components/Sidebar/SidebarBookmarkSection.tsx
+++ b/src/common/components/Sidebar/SidebarBookmarkSection.tsx
@@ -18,7 +18,7 @@ export const SidebarBookmarkSection = () => {
           <h1 className="font-title text-slate-400 text-md">Bookmarks</h1>
         </div>
 
-        <div className="flex flex-col gap-1 mt-1">
+        <div className="flex flex-col">
           {notes.map((note) => (
             <NavItem
               key={note.id}

--- a/src/common/components/Toolbar/Toolbar.tsx
+++ b/src/common/components/Toolbar/Toolbar.tsx
@@ -29,7 +29,7 @@ export const Toolbar = ({
   const shouldReserveWindowButtonSpace = isMac && !isSideBarVisible;
 
   return (
-    <div className="bg-white w-full flex items-center justify-between p-3 electron-drag-region">
+    <div className="bg-white w-full flex items-center justify-between px-3 py-2 border-b border-slate-100 electron-drag-region">
       <div className="flex items-center gap-2">
         {shouldReserveWindowButtonSpace && <div className="h-8 w-[4.5rem]" />}
 

--- a/src/common/components/Toolbar/Toolbar.tsx
+++ b/src/common/components/Toolbar/Toolbar.tsx
@@ -29,7 +29,7 @@ export const Toolbar = ({
   const shouldReserveWindowButtonSpace = isMac && !isSideBarVisible;
 
   return (
-    <div className="bg-white w-full flex items-center justify-between px-3 py-2 border-b border-slate-100 electron-drag-region">
+    <div className="bg-white w-full flex items-center justify-between p-2 border-b border-slate-200 electron-drag-region">
       <div className="flex items-center gap-2">
         {shouldReserveWindowButtonSpace && <div className="h-8 w-[4.5rem]" />}
 

--- a/src/notes/components/NoteEditor/NoteEditor.tsx
+++ b/src/notes/components/NoteEditor/NoteEditor.tsx
@@ -158,8 +158,8 @@ const NoteEditor = ({
   };
 
   return (
-    <div className="flex flex-col items-center gap-4 min-h-full w-full max-w-[1000px] px-12 pt-8">
-      <div className="w-full flex flex-col gap-3 justify-between border-b border-slate-200 pb-4">
+    <div className="flex flex-col items-center gap-4 min-h-full w-full max-w-[1000px] px-8 pt-8">
+      <div className="w-full flex flex-col gap-2 justify-between border-b border-slate-200 pb-4">
         <textarea
           ref={titleRef}
           rows={1}
@@ -170,7 +170,7 @@ const NoteEditor = ({
           className="text-5xl font-title tracking-tight overflow-y-hidden bg-white placeholder-slate-400 select-none resize-none outline-none"
         />
 
-        <div className="flex flex-row flex-wrap gap-x-1.5 gap-y-2 items-center">
+        <div className="flex flex-row flex-wrap gap-1.5 items-center">
           <TagMultiSelect
             key={editedNote.id}
             initialTags={editedNote.tags}
@@ -226,7 +226,7 @@ const NoteEditor = ({
             iconName="bookmark"
           />
 
-          <p className="text-slate-400 text-xs">
+          <p className="text-slate-500 text-xs">
             {editedNote.created.format("D MMMM YYYY, hh:mm a")}
           </p>
 
@@ -265,7 +265,7 @@ const NoteEditor = ({
       </div>
 
       {note.tasks && note.tasks.length > 0 && (
-        <div className="w-full flex flex-col gap-3 justify-between border-b border-slate-200 pb-4">
+        <div className="w-full flex flex-col gap-1 justify-between border-dashed border-b border-slate-300 pb-4">
           {note.tasks.map((task) => (
             <TaskEditor
               key={task.id}
@@ -301,9 +301,9 @@ const NoteEditor = ({
       </div>
 
       {(updates.length > 0 || showNewUpdate) && (
-        <div className="w-full flex flex-col border-t border-slate-200 pt-6">
+        <div className="w-full flex flex-col border-dashed border-t border-slate-300 pt-4 px-1">
           {showNewUpdate && (
-            <div ref={newUpdateRef}>
+            <div ref={newUpdateRef} className="pb-4">
               <UpdateEditor
                 update={{ notes: [editedNote], tint: null }}
                 colour={colour}
@@ -316,7 +316,7 @@ const NoteEditor = ({
           )}
 
           {updates.length > 0 && (
-            <div className="flex flex-col relative">
+            <div className="flex flex-col relative gap-4">
               {[...updates].reverse().map((upd) => (
                 <UpdateEditor
                   key={upd.id}

--- a/src/notes/components/NoteEditor/NoteEditor.tsx
+++ b/src/notes/components/NoteEditor/NoteEditor.tsx
@@ -158,8 +158,8 @@ const NoteEditor = ({
   };
 
   return (
-    <div className="flex flex-col items-center gap-4 min-h-full w-full max-w-[1000px] px-12 pt-6">
-      <div className="w-full flex flex-col gap-2 justify-between border-b-2 border-slate-100 pb-3">
+    <div className="flex flex-col items-center gap-4 min-h-full w-full max-w-[1000px] px-12 pt-8">
+      <div className="w-full flex flex-col gap-3 justify-between border-b border-slate-200 pb-4">
         <textarea
           ref={titleRef}
           rows={1}
@@ -226,7 +226,7 @@ const NoteEditor = ({
             iconName="bookmark"
           />
 
-          <p className="text-slate-500 text-xs">
+          <p className="text-slate-400 text-xs">
             {editedNote.created.format("D MMMM YYYY, hh:mm a")}
           </p>
 
@@ -265,7 +265,7 @@ const NoteEditor = ({
       </div>
 
       {note.tasks && note.tasks.length > 0 && (
-        <div className="w-full flex flex-col gap-2 justify-between border-b-2 border-slate-100 pb-4">
+        <div className="w-full flex flex-col gap-2 justify-between border-b border-slate-200 pb-4">
           {note.tasks.map((task) => (
             <TaskEditor
               key={task.id}
@@ -301,7 +301,7 @@ const NoteEditor = ({
       </div>
 
       {(updates.length > 0 || showNewUpdate) && (
-        <div className="w-full flex flex-col border-t-2 border-slate-100 pt-6">
+        <div className="w-full flex flex-col border-t border-slate-200 pt-6">
           {showNewUpdate && (
             <div ref={newUpdateRef}>
               <UpdateEditor

--- a/src/notes/components/NoteEditor/NoteEditor.tsx
+++ b/src/notes/components/NoteEditor/NoteEditor.tsx
@@ -170,7 +170,7 @@ const NoteEditor = ({
           className="text-5xl font-title tracking-tight overflow-y-hidden bg-white placeholder-slate-400 select-none resize-none outline-none"
         />
 
-        <div className="flex flex-row flex-wrap gap-2 items-center">
+        <div className="flex flex-row flex-wrap gap-x-1.5 gap-y-2 items-center">
           <TagMultiSelect
             key={editedNote.id}
             initialTags={editedNote.tags}
@@ -265,7 +265,7 @@ const NoteEditor = ({
       </div>
 
       {note.tasks && note.tasks.length > 0 && (
-        <div className="w-full flex flex-col gap-2 justify-between border-b border-slate-200 pb-4">
+        <div className="w-full flex flex-col gap-3 justify-between border-b border-slate-200 pb-4">
           {note.tasks.map((task) => (
             <TaskEditor
               key={task.id}

--- a/src/notes/components/NotesLayout/NotesLayout.tsx
+++ b/src/notes/components/NotesLayout/NotesLayout.tsx
@@ -75,7 +75,7 @@ export const NotesLayout = ({
 
   return (
     <div className="flex-1 min-h-0 w-full min-w-0 flex overflow-hidden">
-      <div className="h-full w-64 px-3 flex flex-col gap-5 overflow-y-scroll border-r border-slate-200 bg-slate-50/50">
+      <div className="h-full w-64 px-3 flex flex-col gap-5 overflow-y-scroll border-dashed border-r-2 border-slate-200">
         {(description || (links && links.length > 0)) && (
           <div className="bg-slate-50 p-4 rounded-xl flex flex-col gap-2">
             {description && (

--- a/src/notes/components/NotesLayout/NotesLayout.tsx
+++ b/src/notes/components/NotesLayout/NotesLayout.tsx
@@ -75,7 +75,7 @@ export const NotesLayout = ({
 
   return (
     <div className="flex-1 min-h-0 w-full min-w-0 flex overflow-hidden">
-      <div className="h-full w-64 px-3 flex flex-col gap-5 overflow-y-scroll border-dashed border-r border-slate-200">
+      <div className="h-full w-60 px-3 flex flex-col gap-5 overflow-y-scroll border-r border-slate-200">
         {(description || (links && links.length > 0)) && (
           <div className="bg-slate-50 p-4 rounded-xl flex flex-col gap-2">
             {description && (

--- a/src/notes/components/NotesLayout/NotesLayout.tsx
+++ b/src/notes/components/NotesLayout/NotesLayout.tsx
@@ -75,7 +75,7 @@ export const NotesLayout = ({
 
   return (
     <div className="flex-1 min-h-0 w-full min-w-0 flex overflow-hidden">
-      <div className="h-full w-60 px-4 flex flex-col gap-6 overflow-y-scroll border-dashed border-r-2 border-slate-100">
+      <div className="h-full w-64 px-3 flex flex-col gap-5 overflow-y-scroll border-r border-slate-200 bg-slate-50/50">
         {(description || (links && links.length > 0)) && (
           <div className="bg-slate-50 p-4 rounded-xl flex flex-col gap-2">
             {description && (
@@ -89,7 +89,7 @@ export const NotesLayout = ({
           </div>
         )}
 
-        <div className="h-full flex flex-col gap-4 pb-6">
+        <div className="h-full flex flex-col gap-3 pt-3 pb-6">
           {noteGroups.map((noteGroup) => (
             <NotesList
               key={noteGroup.title ?? "no-title"}

--- a/src/notes/components/NotesLayout/NotesLayout.tsx
+++ b/src/notes/components/NotesLayout/NotesLayout.tsx
@@ -75,7 +75,7 @@ export const NotesLayout = ({
 
   return (
     <div className="flex-1 min-h-0 w-full min-w-0 flex overflow-hidden">
-      <div className="h-full w-64 px-3 flex flex-col gap-5 overflow-y-scroll border-dashed border-r-2 border-slate-200">
+      <div className="h-full w-64 px-3 flex flex-col gap-5 overflow-y-scroll border-dashed border-r border-slate-200">
         {(description || (links && links.length > 0)) && (
           <div className="bg-slate-50 p-4 rounded-xl flex flex-col gap-2">
             {description && (

--- a/src/notes/components/NotesList/NoteListItem.tsx
+++ b/src/notes/components/NotesList/NoteListItem.tsx
@@ -29,17 +29,17 @@ export const NoteListItem = ({
       onMouseOver={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       activeProps={{
-        className: cn(colour.textPill, colour.backgroundPill),
+        className: cn(colour.textPill, colour.backgroundPill, "rounded-lg"),
       }}
       className={cn(
-        "w-full flex justify-between items-center gap-2 px-2 py-1 rounded-xl text-sm transition-colors",
+        "w-full flex justify-between items-center gap-2 px-2 py-1.5 rounded-lg text-sm transition-colors",
         isHovered && colour.textPill,
         isHovered && colour.backgroundPill,
       )}
     >
       {({ isActive }: { isActive: boolean }) => (
         <div key={note.id} className="w-full flex flex-col p-1">
-          <p className="truncate">
+          <p className="truncate font-medium">
             {note.title === "" ? "Untitled Note" : note.title}
           </p>
 

--- a/src/notes/components/NotesList/NoteListItem.tsx
+++ b/src/notes/components/NotesList/NoteListItem.tsx
@@ -38,8 +38,8 @@ export const NoteListItem = ({
       )}
     >
       {({ isActive }: { isActive: boolean }) => (
-        <div key={note.id} className="w-full flex flex-col p-1">
-          <p className="truncate font-medium">
+        <div key={note.id} className="w-full flex flex-col p-0.5">
+          <p className="truncate font-normal">
             {note.title === "" ? "Untitled Note" : note.title}
           </p>
 

--- a/src/notes/components/NotesList/NotesList.tsx
+++ b/src/notes/components/NotesList/NotesList.tsx
@@ -10,16 +10,12 @@ type NotesListProps = {
   colour: Colour;
 };
 
-export const NotesList = ({
-  noteGroup,
-  createdDateFormat,
-  colour,
-}: NotesListProps) => {
+export const NotesList = ({ noteGroup, colour }: NotesListProps) => {
   return (
     <section>
       <div className="flex flex-col gap-0.5 items-start">
         {noteGroup.title && (
-          <h3 className="text-slate-400 text-xs uppercase tracking-wider font-semibold px-2 pb-1 pt-2">
+          <h3 className="text-slate-500 text-xs w-full tracking-wider font-medium px-2 pb-1 pt-2 border-dashed border-b border-slate-300">
             {noteGroup.title}
           </h3>
         )}
@@ -30,23 +26,11 @@ export const NotesList = ({
 
           if (hasNoTitle && hasContent) {
             return (
-              <StickyNoteListItem
-                key={note.id}
-                note={note}
-                createdDateFormat={createdDateFormat}
-                colour={colour}
-              />
+              <StickyNoteListItem key={note.id} note={note} colour={colour} />
             );
           }
 
-          return (
-            <NoteListItem
-              key={note.id}
-              note={note}
-              createdDateFormat={createdDateFormat}
-              colour={colour}
-            />
-          );
+          return <NoteListItem key={note.id} note={note} colour={colour} />;
         })}
       </div>
     </section>

--- a/src/notes/components/NotesList/NotesList.tsx
+++ b/src/notes/components/NotesList/NotesList.tsx
@@ -17,9 +17,11 @@ export const NotesList = ({
 }: NotesListProps) => {
   return (
     <section>
-      <div className="flex flex-col gap-1 items-start">
+      <div className="flex flex-col gap-0.5 items-start">
         {noteGroup.title && (
-          <h3 className="text-slate-400 text-xs">{noteGroup.title}</h3>
+          <h3 className="text-slate-400 text-xs uppercase tracking-wider font-semibold px-2 pb-1 pt-2">
+            {noteGroup.title}
+          </h3>
         )}
 
         {noteGroup.notes.map((note) => {

--- a/src/notes/components/NotesList/StickyNoteListItem.tsx
+++ b/src/notes/components/NotesList/StickyNoteListItem.tsx
@@ -39,7 +39,7 @@ export const StickyNoteListItem = ({
       onMouseOver={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       style={{ "--sticky-rotate": `${rotation}deg` } as React.CSSProperties}
-      className="w-full my-2 text-sm transition-colors [transform:rotate(var(--sticky-rotate,0deg))] motion-reduce:transform-none"
+      className="w-full my-1 text-sm transition-colors [transform:rotate(var(--sticky-rotate,0deg))] motion-reduce:transform-none"
     >
       {({ isActive }: { isActive: boolean }) => {
         const stickyMetaColourClass =
@@ -58,8 +58,8 @@ export const StickyNoteListItem = ({
               <QuillViewer smallViewer content={note.content} />
             </div>
 
-            <div className="flex items-center gap-1">
-              <p className={cn("text-xs pt-0.5", stickyMetaColourClass)}>
+            <div className="flex items-center">
+              <p className={cn("text-xs pt-0.5 pr-1", stickyMetaColourClass)}>
                 {getRelativeDateTitle(note.created, false)}
               </p>
 

--- a/src/tasks/components/CompletedTasksModal/CompletedTasksModal.tsx
+++ b/src/tasks/components/CompletedTasksModal/CompletedTasksModal.tsx
@@ -45,7 +45,10 @@ export const CompletedTasksModal = ({
                   iconName={isCompleted ? "checkCircle" : "xCircle"}
                   size="md"
                   weight="fill"
-                  className="fill-slate-400 mt-px shrink-0"
+                  className={cn(
+                    "mt-px shrink-0",
+                    isCompleted ? colour.text : "text-slate-400",
+                  )}
                 />
                 <div className="flex flex-col">
                   <span

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -319,88 +319,89 @@ export const TaskEditor = ({
         />
       </button>
 
-      <div className="w-full flex items-start justify-between">
-        <div className="flex flex-col grow">
-          <div className="flex items-center flex-1">
-            <textarea
-              ref={titleRef}
-              rows={1}
-              name="title"
-              value={editedTask.title ?? ""}
-              placeholder="No Title"
-              onKeyDown={async (e) => {
-                if (e.key !== "Enter" || e.shiftKey) {
-                  return;
-                }
-
-                e.preventDefault();
-                debouncedSave.flush();
-                await saveRef.current?.();
-                await onCreateNextTask?.();
-              }}
-              onChange={(e) =>
-                onUpdateTask({
-                  title: e.target.value,
-                })
+      <div className="w-full flex-col items-start">
+        <div className="flex justify-between items-start">
+          <textarea
+            ref={titleRef}
+            rows={1}
+            name="title"
+            value={editedTask.title ?? ""}
+            placeholder="No Title"
+            onKeyDown={async (e) => {
+              if (e.key !== "Enter" || e.shiftKey) {
+                return;
               }
-              className={cn(
-                "flex-1 tracking-tight text-md bg-transparent placeholder-slate-400 select-none resize-none outline-none",
-                isCompleted || isCancelled
-                  ? "text-slate-500"
-                  : editedTask.isImportant
-                    ? "text-red-500"
-                    : "text-slate-700",
-                isCancelled && "line-through",
-              )}
-            />
+
+              e.preventDefault();
+              debouncedSave.flush();
+              await saveRef.current?.();
+              await onCreateNextTask?.();
+            }}
+            onChange={(e) =>
+              onUpdateTask({
+                title: e.target.value,
+              })
+            }
+            className={cn(
+              "flex-1 tracking-tight text-md bg-transparent placeholder-slate-400 select-none resize-none outline-none",
+              isCompleted || isCancelled
+                ? "text-slate-500"
+                : editedTask.isImportant
+                  ? "text-red-500"
+                  : "text-slate-700",
+              isCancelled && "line-through",
+            )}
+          />
+
+          <div className="flex flex-row flex-wrap items-center gap-2 pl-1">
+            {editedTask.links.map((link) => (
+              <LinkPill key={link.id} link={link} colour={colour} />
+            ))}
+
+            {editedTask.isImportant && (
+              <Icon
+                iconName="warningCircle"
+                size="sm"
+                className={cn(
+                  "mt-0.5",
+                  isCompleted ? "text-slate-400" : "text-red-500",
+                )}
+              />
+            )}
+
+            {!!editedTask.dueDate && (
+              <span
+                className={cn(
+                  "text-xs px-2 py-1 rounded-full",
+                  isDueDateOverdue
+                    ? "bg-red-100 text-red-500"
+                    : "bg-gray-100 text-gray-500",
+                )}
+              >
+                {editedTask.dueDate.format("MMM D, YYYY")}
+              </span>
+            )}
           </div>
-
-          {showDescription && (
-            <textarea
-              ref={descriptionRef}
-              rows={1}
-              name="description"
-              value={editedTask.description ?? ""}
-              placeholder="No description"
-              onChange={(e) =>
-                onUpdateTask({
-                  description: e.target.value,
-                })
-              }
-              className={cn(
-                "w-full text-[13px] font-normal bg-transparent placeholder-slate-400 select-none resize-none outline-none",
-                isCompleted || isCancelled ? "text-slate-400" : "text-slate-500",
-              )}
-            />
-          )}
         </div>
 
-        <div className="flex flex-row flex-wrap items-center gap-2">
-          {editedTask.links.map((link) => (
-            <LinkPill key={link.id} link={link} colour={colour} />
-          ))}
-
-          {editedTask.isImportant && (
-            <Icon
-              iconName="warningCircle"
-              size="sm"
-              className={isCompleted ? "text-slate-400" : "text-red-500"}
-            />
-          )}
-
-          {!!editedTask.dueDate && (
-            <span
-              className={cn(
-                "text-xs px-2 py-1 rounded-full",
-                isDueDateOverdue
-                  ? "bg-red-100 text-red-500"
-                  : "bg-gray-100 text-gray-500",
-              )}
-            >
-              {editedTask.dueDate.format("MMM D, YYYY")}
-            </span>
-          )}
-        </div>
+        {showDescription && (
+          <textarea
+            ref={descriptionRef}
+            rows={1}
+            name="description"
+            value={editedTask.description ?? ""}
+            placeholder="No description"
+            onChange={(e) =>
+              onUpdateTask({
+                description: e.target.value,
+              })
+            }
+            className={cn(
+              "w-full text-[13px] font-normal bg-transparent placeholder-slate-400 select-none resize-none outline-none",
+              isCompleted || isCancelled ? "text-slate-400" : "text-slate-500",
+            )}
+          />
+        )}
       </div>
 
       <Dialog.Root

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -375,7 +375,10 @@ export const TaskEditor = ({
                   description: e.target.value,
                 })
               }
-              className="w-full text-sm font-normal bg-transparent placeholder-slate-400 text-slate-500 select-none resize-none outline-none"
+              className={cn(
+                "w-full text-sm font-normal bg-transparent placeholder-slate-400 select-none resize-none outline-none",
+                isCompleted || isCancelled ? "text-slate-400" : "text-slate-500",
+              )}
             />
           )}
         </div>

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -286,7 +286,7 @@ export const TaskEditor = ({
 
   return (
     <div
-      className="w-full flex gap-2 items-start"
+      className="w-full flex gap-1 items-start"
       onFocus={() => setIsFocused(true)}
       onBlur={(e) => {
         if (
@@ -300,7 +300,7 @@ export const TaskEditor = ({
       }}
     >
       <button
-        className="pt-px pl-px"
+        className="pt-[3px] pl-px"
         onMouseDown={handleCircleMouseDown}
         onClick={handleCircleClick}
       >
@@ -308,7 +308,7 @@ export const TaskEditor = ({
           iconName={
             isCompleted ? "checkCircle" : isCancelled ? "xCircle" : "circle"
           }
-          size="md"
+          size="sm"
           weight={isCompleted || isCancelled ? "fill" : "regular"}
           className="fill-slate-400 hover:fill-slate-600 transition-colors"
         />
@@ -388,10 +388,10 @@ export const TaskEditor = ({
           {!!editedTask.dueDate && (
             <span
               className={cn(
-                "text-xs px-2.5 py-0.5 rounded-md font-medium",
+                "text-xs px-2 py-1 rounded-full",
                 isDueDateOverdue
                   ? "bg-red-100 text-red-500"
-                  : "bg-slate-100 text-slate-500",
+                  : "bg-gray-100 text-gray-500",
               )}
             >
               {editedTask.dueDate.format("MMM D, YYYY")}

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -384,7 +384,7 @@ export const TaskEditor = ({
             <Icon
               iconName="warningCircle"
               size="sm"
-              className="text-red-500"
+              className={isCompleted ? "text-slate-400" : "text-red-500"}
             />
           )}
 

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -322,19 +322,6 @@ export const TaskEditor = ({
       <div className="w-full flex items-start justify-between">
         <div className="flex flex-col grow">
           <div className="flex items-center flex-1">
-            {editedTask.isImportant && (
-              <Icon
-                iconName="exclamationMark"
-                size="sm"
-                className={cn(
-                  "-ml-2 shrink-0",
-                  isCompleted || isCancelled
-                    ? "text-slate-500"
-                    : "text-red-500",
-                )}
-              />
-            )}
-
             <textarea
               ref={titleRef}
               rows={1}
@@ -392,6 +379,14 @@ export const TaskEditor = ({
           {editedTask.links.map((link) => (
             <LinkPill key={link.id} link={link} colour={colour} />
           ))}
+
+          {editedTask.isImportant && (
+            <Icon
+              iconName="warningCircle"
+              size="sm"
+              className="text-red-500"
+            />
+          )}
 
           {!!editedTask.dueDate && (
             <span

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -381,7 +381,7 @@ export const TaskEditor = ({
                 })
               }
               className={cn(
-                "w-full text-sm font-normal bg-transparent placeholder-slate-400 select-none resize-none outline-none",
+                "w-full text-[13px] font-normal bg-transparent placeholder-slate-400 select-none resize-none outline-none",
                 isCompleted || isCancelled ? "text-slate-400" : "text-slate-500",
               )}
             />

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -388,10 +388,10 @@ export const TaskEditor = ({
           {!!editedTask.dueDate && (
             <span
               className={cn(
-                "text-xs px-2 py-1 rounded-full",
+                "text-xs px-2.5 py-0.5 rounded-md font-medium",
                 isDueDateOverdue
                   ? "bg-red-100 text-red-500"
-                  : "bg-gray-100 text-gray-500",
+                  : "bg-slate-100 text-slate-500",
               )}
             >
               {editedTask.dueDate.format("MMM D, YYYY")}

--- a/src/tasks/components/TaskEditor/TaskEditor.tsx
+++ b/src/tasks/components/TaskEditor/TaskEditor.tsx
@@ -310,7 +310,12 @@ export const TaskEditor = ({
           }
           size="sm"
           weight={isCompleted || isCancelled ? "fill" : "regular"}
-          className="fill-slate-400 hover:fill-slate-600 transition-colors"
+          className={cn(
+            "transition-colors",
+            isCompleted && !isCancelled
+              ? cn(colour.text, colour.textPillInverted)
+              : "text-slate-400 hover:text-slate-600",
+          )}
         />
       </button>
 

--- a/src/updates/components/UpdateEditor/UpdateEditor.tsx
+++ b/src/updates/components/UpdateEditor/UpdateEditor.tsx
@@ -136,10 +136,10 @@ export const UpdateEditor = ({
     <div className="relative">
       <div
         className={cn(
-          "rounded-xl p-2 flex flex-col gap-2 border transition-shadow",
+          "rounded-xl p-2 flex flex-col border transition-shadow",
           isEditing
-            ? "bg-white border-slate-100 shadow-md"
-            : cn("", tintClasses.card, tintClasses.border),
+            ? "bg-white border-slate-100 gap-2"
+            : cn(tintClasses.card, tintClasses.border),
         )}
       >
         {isEditing && (
@@ -213,10 +213,10 @@ export const UpdateEditor = ({
         />
 
         {!isEditing && (
-          <div className="flex items-center justify-between flex-wrap gap-2 mt-0.5">
+          <div className="flex items-center justify-between flex-wrap">
             <div className="flex items-center gap-2 flex-wrap">
               {dateStr && (
-                <span className="text-xs text-slate-400 shrink-0">
+                <span className="text-xs text-slate-400 shrink-0 pl-1 mt-0.5">
                   {dateStr}
                 </span>
               )}

--- a/src/updates/components/UpdateEditor/UpdateEditor.tsx
+++ b/src/updates/components/UpdateEditor/UpdateEditor.tsx
@@ -136,7 +136,7 @@ export const UpdateEditor = ({
     <div className="relative">
       <div
         className={cn(
-          "rounded-2xl p-2 my-2 flex flex-col gap-1 border transition-shadow",
+          "rounded-xl p-3 my-3 flex flex-col gap-2 border transition-shadow",
           isEditing
             ? "bg-white border-slate-100 shadow-md"
             : cn("", tintClasses.card, tintClasses.border),
@@ -216,7 +216,7 @@ export const UpdateEditor = ({
           <div className="flex items-center justify-between flex-wrap gap-2 mt-1">
             <div className="flex items-center gap-2 flex-wrap">
               {dateStr && (
-                <span className="text-xs text-slate-400 shrink-0 pl-1">
+                <span className="text-xs text-slate-400 shrink-0">
                   {dateStr}
                 </span>
               )}

--- a/src/updates/components/UpdateEditor/UpdateEditor.tsx
+++ b/src/updates/components/UpdateEditor/UpdateEditor.tsx
@@ -136,7 +136,7 @@ export const UpdateEditor = ({
     <div className="relative">
       <div
         className={cn(
-          "rounded-xl p-3 my-3 flex flex-col gap-2 border transition-shadow",
+          "rounded-xl p-2 flex flex-col gap-2 border transition-shadow",
           isEditing
             ? "bg-white border-slate-100 shadow-md"
             : cn("", tintClasses.card, tintClasses.border),

--- a/src/updates/components/UpdatesSection/UpdatesSection.tsx
+++ b/src/updates/components/UpdatesSection/UpdatesSection.tsx
@@ -12,7 +12,7 @@ export const UpdatesSection = ({ group, colour }: UpdatesSectionProps) => {
     <section id={group.title} className="w-full flex flex-col gap-2">
       <h2 className="font-title text-3xl">{group.title}</h2>
 
-      <div className="flex flex-col relative">
+      <div className="flex flex-col gap-2 relative">
         {group.updates.map((upd) => (
           <UpdateEditor key={upd.id} update={upd} colour={colour} />
         ))}


### PR DESCRIPTION
This PR refines the Notes and Tasks experience to improve readability and visual hierarchy while keeping behavior and workflows intact.

## What changed
- Updated Notes layout structure and spacing (toolbar/header separation, note list density, section hierarchy, and editor spacing).
- Refined task presentation in `TaskEditor`, including status/detail alignment, important indicator placement, and clearer completed/cancelled visual states.
- Matched icon contrast and visual weight across floating toolbars and formatting controls for consistency.
- Tuned update card and list-item styling to reduce visual noise and make scanning easier.
- Applied related sidebar/header spacing adjustments so the refreshed Notes/Tags experience feels cohesive.

## Notes for review
- This is primarily a styling/layout pass across shared components used by Notes and Tag pages.
- Cancelled task indicators intentionally remain grey while completed indicators adopt the active context colour.